### PR TITLE
Updated to support Kirkstone branch

### DIFF
--- a/README
+++ b/README
@@ -6,7 +6,7 @@ Dependencies
 ============
 
   URI:  https://git.yoctoproject.org/git/poky/meta
-  branch: honister
+  branch: kirkstone
 
 
 Patches

--- a/README
+++ b/README
@@ -34,12 +34,18 @@ II. Misc
 
 The layer contains three recipes for OpenDDS: two versioned, one not.
 
-The versioned receipes are for OpenDDS 3.14 and 3.20, include one of
+The versioned receipes are for OpenDDS 3.14 and 3.20, include
 the following in your local.conf 
 
-  PREFERRED_VERSION:opendds = "3.20"
-  PREFERRED_VERSION:opendds = "3.14"
+  PREFERRED_VERSION_opendds = "3.20" and optionally set ACE_TAO_OPTION to one of the following:
+  ACE_TAO_OPTION = ""             to build with OCI ACE/TAO 2.2a with the latest patches
+  ACE_TAO_OPTION = "--doc-group"  to build with the DOC Group ACE 6.5.16 / TAO 2.5.16 or later in the ACE 6.x / TAO 2.x series
+  ACE_TAO_OPTION = "--doc-group3" to build with the DOC Group ACE 7.0.5 / TAO 3.0.5 or later in the ACE 7.x / TAO 3.x series
 
+  PREFERRED_VERSION_opendds = "3.14" and optionally set ACE_TAO_OPTION to one of the following:
+  ACE_TAO_OPTION = ""             to build with OCI ACE/TAO 2.2a with the latest patches
+  ACE_TAO_OPTION = "--doc-group"  to build with the DOC Group ACE 6.5.16 / TAO 2.5.16 or later in the ACE 6.x / TAO 2.x series
+  
 The unversioned recipe  is provided to allow clients, via a bbappend, to
 build - for example - the HEAD of the master branch or some other version.
 
@@ -47,9 +53,9 @@ To use this unversioned recipe, add the following to your local.conf or
 distro configuration file.
 
 
-    PREFERRED_VERSION:opendds="1.0+git%"
-    PREFERRED_VERSION:opendds-native="1.0+git%"
-    PREFERRED_VERSION:nativesdk-opendds="1.0+git%"
+    PREFERRED_VERSION_opendds="1.0+git%"
+    PREFERRED_VERSION_opendds-native="1.0+git%"
+    PREFERRED_VERSION_nativesdk-opendds="1.0+git%"
     
 
 Note that simply providing a different branch and SRCREV may be insufficient.

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,7 +9,7 @@ BBFILE_COLLECTIONS += "opendds-layer"
 BBFILE_PATTERN_opendds-layer = "^${LAYERDIR}/"
 BBFILE_PRIORITY_opendds-layer = "6"
 
-LAYERSERIES_COMPAT_opendds-layer = "honister"
+LAYERSERIES_COMPAT_opendds-layer = "honister kirkstone"
 LAYERDEPENDS_opendds-layer = "core"
 
 LICENSE_PATH += "${LAYERDIR}/licenses"

--- a/recipes-connectivity/opendds/opendds.inc
+++ b/recipes-connectivity/opendds/opendds.inc
@@ -65,6 +65,9 @@ OECONF:append:class-nativesdk = "\
     --host-tools-only \
 "
 
+# enable do_configure network access to support configure script wget download operations
+do_configure[network] = "1"
+
 do_configure() {
     ./configure ${OECONF}
 }

--- a/recipes-connectivity/opendds/opendds.inc
+++ b/recipes-connectivity/opendds/opendds.inc
@@ -14,26 +14,6 @@ DEPENDS += " \
 
 RDEPENDS:${PN}-dev += " coreutils perl"
 
-DDS_SRC_BRANCH ??= "master"
-SRC_URI = "git://github.com/objectcomputing/OpenDDS.git;protocol=https;branch=${DDS_SRC_BRANCH}"
-
-## pre-fetch ACE/TAO to download, uses the ACE version number
-OCI_TAO_FILE = "ACE+TAO-${OCI_TAO_VERSION}_with_latest_patches_NO_makefiles.tar.gz"
-DOC_TAO2_FILE = "ACE+TAO-src-${DOC_TAO2_VERSION}.tar.gz"
-DOC_TAO3_FILE = "ACE+TAO-src-${DOC_TAO3_VERSION}.tar.gz"
-
-OCI_TAO_URI = "http://download.objectcomputing.com/TAO-${OCI_TAO_VERSION}/${OCI_TAO_FILE}"
-DOC_TAO2_URI = "https://github.com/DOCGroup/ACE_TAO/releases/download/ACE+TAO-${@'${DOC_TAO2_VERSION}'.replace('.','_')}/${DOC_TAO2_FILE}"
-DOC_TAO3_URI = "https://github.com/DOCGroup/ACE_TAO/releases/download/ACE+TAO-${@'${DOC_TAO3_VERSION}'.replace('.','_')}/${DOC_TAO3_FILE}"
-
-ACE_TAO_FILE ??= "${OCI_TAO_FILE}"
-ACE_TAO_URI ??= "${OCI_TAO_URI}"
-ACE_TAO_SHA256SUM ??= "${OCI_TAO_SHA256SUM}"
-ACE_TAO_OPTION ??= ""
-
-SRC_URI += "${ACE_TAO_URI};name=ace_tao;unpack=0"
-SRC_URI[ace_tao.sha256sum] = "${ACE_TAO_SHA256SUM}"
-
 S = "${WORKDIR}/git"
 
 # Set the build directory to be the source directory
@@ -84,7 +64,6 @@ OECONF:append:class-nativesdk = "\
 "
 
 do_configure() {
-    cp ${DL_DIR}/${ACE_TAO_FILE} ${S}
     ./configure ${OECONF}
 }
 

--- a/recipes-connectivity/opendds/opendds.inc
+++ b/recipes-connectivity/opendds/opendds.inc
@@ -17,6 +17,23 @@ RDEPENDS:${PN}-dev += " coreutils perl"
 DDS_SRC_BRANCH ??= "master"
 SRC_URI = "git://github.com/objectcomputing/OpenDDS.git;protocol=https;branch=${DDS_SRC_BRANCH}"
 
+## pre-fetch ACE/TAO to download, uses the ACE version number
+OCI_TAO_FILE = "ACE+TAO-${OCI_TAO_VERSION}_with_latest_patches_NO_makefiles.tar.gz"
+DOC_TAO2_FILE = "ACE+TAO-src-${DOC_TAO2_VERSION}.tar.gz"
+DOC_TAO3_FILE = "ACE+TAO-src-${DOC_TAO3_VERSION}.tar.gz"
+
+OCI_TAO_URI = "http://download.objectcomputing.com/TAO-${OCI_TAO_VERSION}/${OCI_TAO_FILE}"
+DOC_TAO2_URI = "https://github.com/DOCGroup/ACE_TAO/releases/download/ACE+TAO-${@'${DOC_TAO2_VERSION}'.replace('.','_')}/${DOC_TAO2_FILE}"
+DOC_TAO3_URI = "https://github.com/DOCGroup/ACE_TAO/releases/download/ACE+TAO-${@'${DOC_TAO3_VERSION}'.replace('.','_')}/${DOC_TAO3_FILE}"
+
+ACE_TAO_FILE ??= "${OCI_TAO_FILE}"
+ACE_TAO_URI ??= "${OCI_TAO_URI}"
+ACE_TAO_SHA256SUM ??= "${OCI_TAO_SHA256SUM}"
+ACE_TAO_OPTION ??= ""
+
+SRC_URI += "${ACE_TAO_URI};name=ace_tao;unpack=0"
+SRC_URI[ace_tao.sha256sum] = "${ACE_TAO_SHA256SUM}"
+
 S = "${WORKDIR}/git"
 
 # Set the build directory to be the source directory
@@ -48,6 +65,7 @@ OECONF:append = "\
     --prefix=${prefix} \
     --verbose \
     --no-tests \
+    ${ACE_TAO_OPTION} \
 "
 
 OECONF:append:class-target = "\
@@ -65,10 +83,8 @@ OECONF:append:class-nativesdk = "\
     --host-tools-only \
 "
 
-# enable do_configure network access to support configure script wget download operations
-do_configure[network] = "1"
-
 do_configure() {
+    cp ${DL_DIR}/${ACE_TAO_FILE} ${S}
     ./configure ${OECONF}
 }
 

--- a/recipes-connectivity/opendds/opendds_3.14.bb
+++ b/recipes-connectivity/opendds/opendds_3.14.bb
@@ -3,7 +3,20 @@
 SRCREV = "16b426a3ccdba5360b06d9bff625c56dc04e511f"
 DDS_SRC_BRANCH = "branch-DDS-3.14"
 
+OCI_TAO_VERSION = "2.2a"
+DOC_TAO2_VERSION = "6.5.8"
+
+OCI_TAO_SHA256SUM = "bc51c94495fd9d9dd43f4d86405f67a7a8a646e752b104f50243c9cefaed2b6c"
+DOC_TAO2_SHA256SUM = "4d1f0b12553f777804b4b79935db515e7212f24aa07b7616aa914a22f8579019"
+
 require opendds.inc
+
+python () {
+    if d.getVar('ACE_TAO_OPTION') == '--doc-group':
+        d.setVar('ACE_TAO_FILE', '${DOC_TAO2_FILE}')
+        d.setVar('ACE_TAO_URI', '${DOC_TAO2_URI}')
+        d.setVar('ACE_TAO_SHA256SUM', '${DOC_TAO2_SHA256SUM}')
+}
 
 do_install:append:class-native() {
     # Prepare HOST_ROOT expected by DDS for target build

--- a/recipes-connectivity/opendds/opendds_3.14.bb
+++ b/recipes-connectivity/opendds/opendds_3.14.bb
@@ -2,6 +2,9 @@
 
 SRCREV = "16b426a3ccdba5360b06d9bff625c56dc04e511f"
 DDS_SRC_BRANCH = "branch-DDS-3.14"
+SRC_URI = "git://github.com/objectcomputing/OpenDDS.git;protocol=https;branch=${DDS_SRC_BRANCH};name=opendds"
+
+require opendds.inc
 
 OCI_TAO_VERSION = "2.2a"
 DOC_TAO2_VERSION = "6.5.8"
@@ -9,14 +12,21 @@ DOC_TAO2_VERSION = "6.5.8"
 OCI_TAO_SHA256SUM = "bc51c94495fd9d9dd43f4d86405f67a7a8a646e752b104f50243c9cefaed2b6c"
 DOC_TAO2_SHA256SUM = "4d1f0b12553f777804b4b79935db515e7212f24aa07b7616aa914a22f8579019"
 
-require opendds.inc
+OCI_TAO_URI = "http://download.objectcomputing.com/TAO-${OCI_TAO_VERSION}/ACE+TAO-${OCI_TAO_VERSION}_with_latest_patches_NO_makefiles.tar.gz"
+DOC_TAO2_URI = "https://github.com/DOCGroup/ACE_TAO/releases/download/ACE+TAO-${@'${DOC_TAO2_VERSION}'.replace('.','_')}/ACE+TAO-src-${DOC_TAO2_VERSION}.tar.gz"
+
+ACE_TAO_OPTION ??= ""
+ACE_TAO_URI ??= "${OCI_TAO_URI}" 
+ACE_TAO_SHA256SUM ??= "${OCI_TAO_SHA256SUM}" 
 
 python () {
     if d.getVar('ACE_TAO_OPTION') == '--doc-group':
-        d.setVar('ACE_TAO_FILE', '${DOC_TAO2_FILE}')
         d.setVar('ACE_TAO_URI', '${DOC_TAO2_URI}')
         d.setVar('ACE_TAO_SHA256SUM', '${DOC_TAO2_SHA256SUM}')
 }
+
+SRC_URI += "${ACE_TAO_URI};name=ace_tao;unpack=0;subdir=git"
+SRC_URI[ace_tao.sha256sum] = "${ACE_TAO_SHA256SUM}"
 
 do_install:append:class-native() {
     # Prepare HOST_ROOT expected by DDS for target build

--- a/recipes-connectivity/opendds/opendds_3.20.bb
+++ b/recipes-connectivity/opendds/opendds_3.20.bb
@@ -3,7 +3,27 @@
 SRCREV = "bf1b1df276f41baa2f85de103e95fe3f94b4dcc6"
 DDS_SRC_BRANCH = "branch-DDS-3.20"
 
+OCI_TAO_VERSION = "2.2a"
+DOC_TAO2_VERSION = "6.5.16"
+DOC_TAO3_VERSION = "7.0.6"
+
+OCI_TAO_SHA256SUM = "bc51c94495fd9d9dd43f4d86405f67a7a8a646e752b104f50243c9cefaed2b6c"
+DOC_TAO2_SHA256SUM = "c10a89cae08bf9b6d7bda166a1e35d3a737b726544c276b20b3cc7eb9c75a363"
+DOC_TAO3_SHA256SUM = "590506ec126fd07b9b63dcdf86175d1b5c42c82b7f9fd180b6bf4ffcb8f95457"
+
 require opendds.inc
+
+python () {
+    if d.getVar('ACE_TAO_OPTION') == '--doc-group':
+        d.setVar('ACE_TAO_FILE', '${DOC_TAO2_FILE}')
+        d.setVar('ACE_TAO_URI', '${DOC_TAO2_URI}')
+        d.setVar('ACE_TAO_SHA256SUM', '${DOC_TAO2_SHA256SUM}')
+
+    elif d.getVar('ACE_TAO_OPTION') == '--doc-group3':
+        d.setVar('ACE_TAO_FILE', '${DOC_TAO3_FILE}')
+        d.setVar('ACE_TAO_URI', '${DOC_TAO3_URI}')
+        d.setVar('ACE_TAO_SHA256SUM', '${DOC_TAO3_SHA256SUM}')
+}
 
 do_install:append:class-native() {
     # Prepare HOST_ROOT expected by DDS for target build

--- a/recipes-connectivity/opendds/opendds_3.20.bb
+++ b/recipes-connectivity/opendds/opendds_3.20.bb
@@ -2,6 +2,9 @@
 
 SRCREV = "bf1b1df276f41baa2f85de103e95fe3f94b4dcc6"
 DDS_SRC_BRANCH = "branch-DDS-3.20"
+SRC_URI = "git://github.com/objectcomputing/OpenDDS.git;protocol=https;branch=${DDS_SRC_BRANCH};name=opendds"
+
+require opendds.inc
 
 OCI_TAO_VERSION = "2.2a"
 DOC_TAO2_VERSION = "6.5.16"
@@ -11,19 +14,25 @@ OCI_TAO_SHA256SUM = "bc51c94495fd9d9dd43f4d86405f67a7a8a646e752b104f50243c9cefae
 DOC_TAO2_SHA256SUM = "c10a89cae08bf9b6d7bda166a1e35d3a737b726544c276b20b3cc7eb9c75a363"
 DOC_TAO3_SHA256SUM = "590506ec126fd07b9b63dcdf86175d1b5c42c82b7f9fd180b6bf4ffcb8f95457"
 
-require opendds.inc
+OCI_TAO_URI = "http://download.objectcomputing.com/TAO-${OCI_TAO_VERSION}/ACE+TAO-${OCI_TAO_VERSION}_with_latest_patches_NO_makefiles.tar.gz"
+DOC_TAO2_URI = "https://github.com/DOCGroup/ACE_TAO/releases/download/ACE+TAO-${@'${DOC_TAO2_VERSION}'.replace('.','_')}/ACE+TAO-src-${DOC_TAO2_VERSION}.tar.gz"
+DOC_TAO3_URI = "https://github.com/DOCGroup/ACE_TAO/releases/download/ACE+TAO-${@'${DOC_TAO3_VERSION}'.replace('.','_')}/ACE+TAO-src-${DOC_TAO3_VERSION}.tar.gz"
+
+ACE_TAO_OPTION ??= ""
+ACE_TAO_URI ??= "${OCI_TAO_URI}" 
+ACE_TAO_SHA256SUM ??= "${OCI_TAO_SHA256SUM}" 
 
 python () {
     if d.getVar('ACE_TAO_OPTION') == '--doc-group':
-        d.setVar('ACE_TAO_FILE', '${DOC_TAO2_FILE}')
         d.setVar('ACE_TAO_URI', '${DOC_TAO2_URI}')
         d.setVar('ACE_TAO_SHA256SUM', '${DOC_TAO2_SHA256SUM}')
-
     elif d.getVar('ACE_TAO_OPTION') == '--doc-group3':
-        d.setVar('ACE_TAO_FILE', '${DOC_TAO3_FILE}')
         d.setVar('ACE_TAO_URI', '${DOC_TAO3_URI}')
         d.setVar('ACE_TAO_SHA256SUM', '${DOC_TAO3_SHA256SUM}')
 }
+
+SRC_URI += "${ACE_TAO_URI};name=ace_tao;unpack=0;subdir=git"
+SRC_URI[ace_tao.sha256sum] = "${ACE_TAO_SHA256SUM}"
 
 do_install:append:class-native() {
     # Prepare HOST_ROOT expected by DDS for target build

--- a/recipes-connectivity/opendds/opendds_git.bb
+++ b/recipes-connectivity/opendds/opendds_git.bb
@@ -27,12 +27,6 @@ do_configure[network] = "1"
 
 require opendds.inc
 
-# DOC_TAO2_VERSION = "6.5.16"
-# DOC_TAO2_SHA256SUM = "c10a89cae08bf9b6d7bda166a1e35d3a737b726544c276b20b3cc7eb9c75a363"
-# DOC_TAO2_URI = "https://github.com/DOCGroup/ACE_TAO/releases/download/ACE+TAO-${@'${DOC_TAO2_VERSION}'.replace('.','_')}/ACE+TAO-src-${DOC_TAO2_VERSION}.tar.gz"
-# SRC_URI += "${DOC_TAO2_URI};name=ace_tao;unpack=0;subdir=git"
-# SRC_URI[ace_tao.sha256sum] = "${DOC_TAO2_SHA256SUM}"
-
 do_install:append:class-target() {
     sed -i -e s:${S}/::g ${D}${libdir}/cmake/OpenDDS/config.cmake
 }

--- a/recipes-connectivity/opendds/opendds_git.bb
+++ b/recipes-connectivity/opendds/opendds_git.bb
@@ -14,11 +14,24 @@ DEFAULT_PREFERENCE = "-1"
 SRCREV = "${AUTOREV}"
 PV = "1.0+git${SRCPV}"
 
+DDS_SRC_BRANCH ??= "master"
+SRC_URI = "git://github.com/objectcomputing/OpenDDS.git;protocol=https;branch=${DDS_SRC_BRANCH}"
+
 OECONF = " \
     --ace-github-latest \
 "
 
+ACE_TAO_OPTION = ""
+
+do_configure[network] = "1"
+
 require opendds.inc
+
+# DOC_TAO2_VERSION = "6.5.16"
+# DOC_TAO2_SHA256SUM = "c10a89cae08bf9b6d7bda166a1e35d3a737b726544c276b20b3cc7eb9c75a363"
+# DOC_TAO2_URI = "https://github.com/DOCGroup/ACE_TAO/releases/download/ACE+TAO-${@'${DOC_TAO2_VERSION}'.replace('.','_')}/ACE+TAO-src-${DOC_TAO2_VERSION}.tar.gz"
+# SRC_URI += "${DOC_TAO2_URI};name=ace_tao;unpack=0;subdir=git"
+# SRC_URI[ace_tao.sha256sum] = "${DOC_TAO2_SHA256SUM}"
 
 do_install:append:class-target() {
     sed -i -e s:${S}/::g ${D}${libdir}/cmake/OpenDDS/config.cmake


### PR DESCRIPTION
Updated to support kirkstone. kirkstone by default disables network access for all recipe tasks except do_fetch, so enabled network access for do_configure to support configure script wget operations. 