### PR TITLE
Add yocto-check-layer ci workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# Set update schedule for GitHub Actions
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/scripts/yocto-check-layer.sh
+++ b/.github/scripts/yocto-check-layer.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+export DEFAULT_YOCTO_BRANCH="master"
+
+if [[ -z "${YOCTO_RELEASE}" ]]; then
+  export YOCTO_RELEASE=$DEFAULT_YOCTO_BRANCH
+fi
+
+cd $RUNNER_TEMP
+git clone --depth 1 --branch $YOCTO_RELEASE https://git.yoctoproject.org/git/poky 
+. ./poky/oe-init-build-env build
+yocto-check-layer --with-software-layer-signature-check --debug "$GITHUB_WORKSPACE"

--- a/.github/workflows/yocto-layer-check.yml
+++ b/.github/workflows/yocto-layer-check.yml
@@ -1,0 +1,28 @@
+name: Run Yocto Check Layer
+on: 
+  pull_request:
+    types: [opened, reopened]
+  workflow_dispatch:
+
+env:
+  YOCTO_RELEASE: kirkstone
+
+jobs:
+  yocto-check-layer:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Install yocto build dependancies
+        run: |
+          sudo apt-get update
+          sudo apt-get install gawk wget git diffstat unzip texinfo gcc \
+          build-essential chrpath socat cpio python3 python3-pip python3-pexpect \
+          xz-utils debianutils iputils-ping python3-git python3-jinja2 \
+          libegl1-mesa libsdl1.2-dev pylint3 xterm python3-subunit \
+          mesa-common-dev zstd liblz4-tool
+          
+      - name: Check out meta-opendds repo
+        uses: actions/checkout@v3
+        
+      - name: Run yocto check layer script
+        run: |
+          "${GITHUB_WORKSPACE}/.github/scripts/yocto-check-layer.sh"


### PR DESCRIPTION
Add CI workflow to run yocto-check-layer on the master branch of the repo when a pull request is opened/reopened or it can be run adhoc with a github action  workflow_dispatch event. The workflow runs on a ubuntu-20.04 github action runner that installs  the required packages for yocto build dependencies before running a bash script that clones the yocto kirkstone branch and runs the yocto-check-layer on the meta-opendds pull reqeust or master branch. 
  